### PR TITLE
feat: = char required now for vars

### DIFF
--- a/examples/complex1.ts
+++ b/examples/complex1.ts
@@ -2,7 +2,7 @@ import { parse } from "../src/parser/index.ts";
 import { compile } from "../src/compiler/index.ts";
 
 const obj = parse(`
-$variable: #ff000
+$variable: = #ff000
 div:
   span:
     ~ fdsqfdsq:

--- a/src/compiler/compiler.ts
+++ b/src/compiler/compiler.ts
@@ -24,11 +24,11 @@ function recursiveCompilation(json: { [k: string]: any }, collection: Map<string
             parentId: opts.id || null,
           });
         break;
-      case key.startsWith('$') && isTopLevel && typeof json[key] !== 'object':
+      case key.startsWith('$') && isTopLevel && typeof json[key] !== 'object' && json[key].startsWith('='):
         const varId = 'a' + Math.random(); // TODO: use uuid module
         collection.set(varId, {
           type: 'variable',
-          value: json[key],
+          value: json[key].substring(1).trim(),
           name: key,
           id: varId,
           parentId: opts.id || null,


### PR DESCRIPTION
`$var: = value`

nice to have:
transform `$token:= value` to `$token: = value`
using the transformation is to avoid YAML Parser error